### PR TITLE
Example: switch from ESM to CJS for compatibility with remix-electron

### DIFF
--- a/desktop/index.js
+++ b/desktop/index.js
@@ -10,6 +10,7 @@ app.on("ready", async () => {
   try {
     const url = await initRemix({
       serverBuild: join(__dirname, "../build/index.js"),
+      publicFolder: join(__dirname, "../public"),
     });
 
     win = new BrowserWindow({ show: false });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remix-electron-issue",
   "private": true,
   "sideEffects": false,
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "build": "remix build",
     "dev": "remix dev --manual",

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@remix-run/dev').AppConfig} */
-export default {
+module.exports = {
   ignoredRouteFiles: ["**/*.css"],
+  serverModuleFormat: "cjs",
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",


### PR DESCRIPTION
For now, if you want to use remix-electron, you may be able to move your project from ESM back down to CJS. This PR shows the diff.